### PR TITLE
Fix wasm build

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -611,10 +611,9 @@ fn update_leaderboard(
         .map(|(i, player)| (player.distance, player.end, i))
         .collect::<Vec<_>>();
     player_order.sort_unstable_by(|a, b| {
-        a.0.partial_cmp(&b.0).unwrap().then_with(|| {
-            let old = Instant::now() - Duration::from_secs(100000);
-            a.1.unwrap_or(old).cmp(&b.1.unwrap_or(old))
-        })
+        a.0.partial_cmp(&b.0)
+            .unwrap()
+            .then_with(|| a.1.unwrap_or(round.start).cmp(&b.1.unwrap_or(round.start)))
     });
     for (player, mut text) in distances.iter_mut() {
         let list_index = player.index;


### PR DESCRIPTION
`Instant::now()` behaves differently there. It seems to use the app start time as its epoch.

I'm pretty sure that this change preserves the intent of the code while working around that.

I think you may have gone to bed already, but if not, there's an hour left to the deadline!